### PR TITLE
Revert unauthorized auth change

### DIFF
--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -129,23 +129,10 @@ class BearerTokenAuthMiddleware(Middleware):
         return await call_next(context)
 
     async def on_list_tools(self, context: MiddlewareContext, call_next):
-        """
-        Allow tool listing without authentication.
-
-        Tool listings are public API documentation and don't expose sensitive data.
-        This also allows FastMCP Cloud's inspection process to work during deployment.
-        Authorization is still enforced when tools are actually called via on_call_tool.
-        """
-        # Try to authenticate if headers are present, but don't require it
-        try:
-            principal = self._authenticate()
-            if context.fastmcp_context:
-                context.fastmcp_context.set_state('api_principal', principal)
-        except McpError:
-            # Allow unauthenticated tool listing - it's just API documentation
-            logger.debug('Allowing unauthenticated tool listing')
-            pass
-
+        """Authenticate before listing tools."""
+        principal = self._authenticate()
+        if context.fastmcp_context:
+            context.fastmcp_context.set_state('api_principal', principal)
         return await call_next(context)
 
     async def on_initialize(self, context: MiddlewareContext, call_next):


### PR DESCRIPTION
## Summary
Reverts commit f9ee701 which allowed unauthenticated tool listing.

This restores the fully tested and documented authentication behavior where `on_list_tools` requires authentication.

## What was reverted
The `on_list_tools` method in `src/middleware/auth.py` now requires authentication again (as originally implemented and tested in PR #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)