### PR TITLE
fix: handle Neo4j 5.x race condition during index creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,6 +596,16 @@ curl http://localhost:7474
 - Verify managed identity has appropriate permissions
 - Set USE_AZURE_AD=true in .env
 
+**Neo4j 5.x index creation warnings:**
+```
+Warning: Index creation race condition detected (Neo4j 5.x issue). Indexes likely already exist. Continuing...
+```
+- This is a known Neo4j 5.x issue with concurrent `CREATE INDEX ... IF NOT EXISTS` statements
+- The warning is harmless - the server continues to function normally
+- Indexes are created successfully on the first attempt; subsequent parallel attempts may trigger the warning
+- This does not affect functionality or performance
+- Related: [Neo4j Issue #13208](https://github.com/neo4j/neo4j/issues/13208), [Graphiti PR #1081](https://github.com/getzep/graphiti/pull/1081)
+
 ## Operational Utilities
 
 ### Backup and Restore

--- a/tests/test_neo4j_race_condition.py
+++ b/tests/test_neo4j_race_condition.py
@@ -1,0 +1,118 @@
+"""Tests for Neo4j 5.x race condition handling during index creation."""
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.requires_neo4j
+async def test_neo4j_index_race_condition_handled():
+    """Test that EquivalentSchemaRuleAlreadyExists is gracefully handled."""
+    from config.schema import ServerConfig
+    from src.server import GraphitiService
+
+    # Create a properly configured mock config
+    config = MagicMock(spec=ServerConfig)
+    config.database = MagicMock()
+    config.database.provider = 'neo4j'
+    config.llm = MagicMock()
+    config.llm.provider = 'openai'
+    config.embedder = MagicMock()
+    config.embedder.provider = 'openai'
+    config.graphiti = MagicMock()
+    config.graphiti.group_id = 'test_group'
+
+    service = GraphitiService(config)
+
+    # Mock the Graphiti client to raise the race condition error
+    mock_client = AsyncMock()
+    mock_error = Exception('Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists')
+    mock_client.build_indices_and_constraints.side_effect = mock_error
+
+    with (
+        patch('src.server.Graphiti', return_value=mock_client),
+        patch('services.factories.LLMClientFactory.create', return_value=AsyncMock()),
+        patch('services.factories.EmbedderFactory.create', return_value=AsyncMock()),
+    ):
+        # Should complete without raising
+        await service.initialize()
+
+        # Verify client was created
+        assert service.client is not None
+
+
+@pytest.mark.integration
+@pytest.mark.requires_neo4j
+async def test_neo4j_other_index_errors_are_raised():
+    """Test that non-race-condition errors are properly raised."""
+    from config.schema import ServerConfig
+    from src.server import GraphitiService
+
+    # Create a properly configured mock config
+    config = MagicMock(spec=ServerConfig)
+    config.database = MagicMock()
+    config.database.provider = 'neo4j'
+    config.llm = MagicMock()
+    config.llm.provider = 'openai'
+    config.embedder = MagicMock()
+    config.embedder.provider = 'openai'
+    config.graphiti = MagicMock()
+    config.graphiti.group_id = 'test_group'
+
+    service = GraphitiService(config)
+
+    # Mock the Graphiti client to raise a different error
+    mock_client = AsyncMock()
+    mock_error = Exception('Some other database error')
+    mock_client.build_indices_and_constraints.side_effect = mock_error
+
+    # Should raise the original error
+    with (
+        patch('src.server.Graphiti', return_value=mock_client),
+        patch('services.factories.LLMClientFactory.create', return_value=AsyncMock()),
+        patch('services.factories.EmbedderFactory.create', return_value=AsyncMock()),
+        pytest.raises(Exception, match='Some other database error'),
+    ):
+        await service.initialize()
+
+
+@pytest.mark.integration
+@pytest.mark.requires_neo4j
+async def test_neo4j_race_condition_logs_warning(caplog):
+    """Test that race condition triggers a warning log."""
+    from config.schema import ServerConfig
+    from src.server import GraphitiService
+
+    # Create a properly configured mock config
+    config = MagicMock(spec=ServerConfig)
+    config.database = MagicMock()
+    config.database.provider = 'neo4j'
+    config.llm = MagicMock()
+    config.llm.provider = 'openai'
+    config.embedder = MagicMock()
+    config.embedder.provider = 'openai'
+    config.graphiti = MagicMock()
+    config.graphiti.group_id = 'test_group'
+
+    service = GraphitiService(config)
+
+    # Mock the Graphiti client to raise the race condition error
+    mock_client = AsyncMock()
+    mock_error = Exception('Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists')
+    mock_client.build_indices_and_constraints.side_effect = mock_error
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch('src.server.Graphiti', return_value=mock_client),
+        patch('services.factories.LLMClientFactory.create', return_value=AsyncMock()),
+        patch('services.factories.EmbedderFactory.create', return_value=AsyncMock()),
+    ):
+        await service.initialize()
+
+        # Verify warning was logged
+        assert any(
+            'Index creation race condition detected' in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary
Fixes a race condition that causes the Graphiti MCP server to crash on startup when using Neo4j 5.x as the database backend.

## Problem Description
**Error**: `Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists`

**Root Cause**: Neo4j 5.x has a known issue where concurrent `CREATE INDEX ... IF NOT EXISTS` statements can fail even with the guard clause. The upstream `graphiti_core` library runs ~19 index creation queries in parallel via `semaphore_gather()`, triggering this race condition.

**Impact**: MCP server crashes during initialization, making Neo4j 5.x deployments non-functional.

## Solution
Wrap `build_indices_and_constraints()` calls with try/except to catch and gracefully handle the `EquivalentSchemaRuleAlreadyExists` error. The indexes are successfully created by whichever parallel query completes first, so we can safely continue execution.

## Changes
- ✅ `src/server.py`: Add race condition error handling (production entrypoint)
- ✅ `src/graphiti_mcp_server.py`: Add race condition error handling (legacy entrypoint)
- ✅ `tests/test_neo4j_race_condition.py`: Integration tests for error handling
- ✅ `CLAUDE.md`: Document the warning message in troubleshooting section

## Testing
**Before Fix**:
```bash
$ docker compose -f docker/docker-compose-neo4j.yml up -d
# Container exits with code 1
neo4j.exceptions.ClientError: {neo4j_code: Neo.ClientError.Schema.EquivalentSchemaRuleAlreadyExists}
```

**After Fix**:
```bash
$ docker compose -f docker/docker-compose-neo4j.yml up -d
$ docker logs docker-graphiti-mcp-1
# Output:
2025-11-24 - graphiti_mcp_server - WARNING - Index creation race condition detected (Neo4j 5.x issue). Indexes likely already exist. Continuing...
2025-11-24 - graphiti_mcp_server - INFO - Successfully initialized Graphiti client

$ curl http://localhost:8000/health
{"status":"healthy","service":"graphiti-mcp"}
```

**Integration Tests**:
- ✅ Race condition error is caught and logged as warning
- ✅ Other errors are properly re-raised
- ✅ Server initializes successfully after handling race condition
- ✅ All existing tests pass

## References
- Upstream PR: https://github.com/getzep/graphiti/pull/1081#issuecomment-3568984731
- Neo4j Issue: https://github.com/neo4j/neo4j/issues/13208

## Checklist
- [x] Fix handles the specific EquivalentSchemaRuleAlreadyExists error
- [x] Other exceptions are re-raised (not silently swallowed)
- [x] Warning message is logged for visibility
- [x] Changes applied to both server entrypoints (factory + legacy)
- [x] Integration tests added
- [x] Documentation updated
- [x] Manual testing with Neo4j 5.26.0 successful
- [x] No impact on FalkorDB backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)